### PR TITLE
hyp-989: add hypermode schema JSON

### DIFF
--- a/hypermode.schema.json
+++ b/hypermode.schema.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/hypermode.json",
+  "additionalProperties": true,
+  "properties": {
+    "properties": {
+      "hosts": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name", "endpoint"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Internal name of your host. Used for indicating the host of a model or for a connection."
+            },
+            "endpoint": {
+              "type": "string",
+              "format": "uri",
+              "description": "URL and base path for connections to the host."
+            }
+          }
+        }
+      },
+      "models": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": ["name", "task", "sourceModel", "provider", "host"],
+          "properties": {
+            "host": {
+              "type": "string",
+              "description": "Runtime provider of model. Can be dynamically deployed models on Hypermode or a project-defined host."
+            },
+            "name": {
+              "type": "string",
+              "description": "Internal name of your AI model. Used for indicating the model to use in an API call."
+            },
+            "provider": {
+              "type": "string",
+              "description": "Source location of model, such as 'hugging-face' or 'openai'."
+            },
+            "sourceModel": {
+              "type": "string",
+              "description": "Relative path of model within provider."
+            },
+            "task": {
+              "type": "string",
+              "description": "Training intent of model, such as 'classification' or 'embedding'."
+            }
+          }
+        }
+      }
+    }
+  },
+  "type": "object"
+}


### PR DESCRIPTION
Once our schema is finalized, we can publish to SchemaStore, and all these editor users will automatically benefit from auto-completion and error-checking. This preemptively prevents user from authoring a `hypermode.json` with the wrong format.

<img width="858" alt="image" src="https://github.com/gohypermode/docs/assets/4033249/0470d52b-96f9-41b2-9c94-328f302d5a5d">

One open question: should we add a `version` field? See this doc about `agriparc.json`: https://github.com/SchemaStore/schemastore/blob/master/CONTRIBUTING.md#how-to-add-a-json-schema-with-multiple-versions

As we add/update the fields, the `version` becomes a way for us to track the diff in `hypermode.json` format.
Also I imagine if we introduce some new capabilities, it would be great to make it a manual upgrade. For example we can say "roll this out to users on hypermode.json v0.5 and above", and users would manually update the `version` key to use the new capabilities.

