### PR TITLE
Update model and host docs for new manifest format

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "unifiedjs.vscode-mdx"
+    "unifiedjs.vscode-mdx",
+    "chrischinchilla.vale-vscode"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,6 @@
     "chrischinchilla.vale-vscode",
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "trunk.io",
     "unifiedjs.vscode-mdx"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "streetsidesoftware.code-spell-checker",
+    "unifiedjs.vscode-mdx"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,9 @@
 {
   "recommendations": [
+    "chrischinchilla.vale-vscode",
     "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
-    "unifiedjs.vscode-mdx",
-    "chrischinchilla.vale-vscode"
+    "trunk.io",
+    "unifiedjs.vscode-mdx"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+  "editor.formatOnSave": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[mdx]": {
+    "editor.defaultFormatter": "unifiedjs.vscode-mdx"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,5 +10,6 @@
   },
   "[mdx]": {
     "editor.defaultFormatter": "unifiedjs.vscode-mdx"
-  }
+  },
+  "cSpell.enableFiletypes": ["mdx"]
 }

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ npm i -g mintlify
 
 Validate alignment of changes with style guide.
 
-https://vale.sh/docs/vale-cli/installation/
-
 MacOS:
 
 ```bash
 brew install vale
 ```
+
+[Full Installation Docs](https://vale.sh/docs/vale-cli/installation/)
 
 ### Trunk CLI
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ mintlify dev
 
 Consistency is important in any documentation experience. Beyond Markdown’s opinionated structure, we adhere to a consistent style for Hypermode.
 
-We have adopted [Google’s Developer Documentation Style Guide](https://developers.google.com/style/) as a baseline, with Hypermode-specific terms [stored in a vocabulary file](https://github.com/hypermodeAI/docs/blob/9b3f5c88a4274c549d65288339a4f7c5a7d6ae2a/styles/config/vocabularies/general/accept.txt).
+We have adopted [Google’s Developer Documentation Style Guide](https://developers.google.com/style/) as a baseline, with Hypermode-specific terms [stored in a vocabulary file](./styles/config/vocabularies/general/accept.txt).
 
 [Vale](https://vale.sh/) has been implemented in the repo for easy alignment. Vale is implemented within CI/CD, but also executable locally with:
 

--- a/README.md
+++ b/README.md
@@ -88,3 +88,10 @@ To run lint checks, run:
 ```bash
 trunk check # appending --all will run checks beyond changes on the current branch
 ```
+
+Note that Trunk also has a [VS Code extension](https://marketplace.visualstudio.com/items?itemName=Trunk.io) you can install.
+
+However, when installing it please be aware of the `trunk.autoInit` setting, which is `true` (enabled) by default
+This controls whether to auto-initialize trunk in non-trunk repositories - meaning _any_ folder you open with VS Code will get
+configured with a `.trunk` subfolder, and will start using Trunk. You should probably set this to `false` in your VS Code user settings,
+to not interfere with other projects you may be working on.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,12 @@ npm i -g mintlify
 
 Validate alignment of changes with style guide.
 
+https://vale.sh/docs/vale-cli/installation/
+
+MacOS:
+
 ```bash
-npm i -D @ocular-d/vale-bin
+brew install vale
 ```
 
 ### Trunk CLI
@@ -37,7 +41,7 @@ npm i -D @ocular-d/vale-bin
 Format and lint changes for easy merging.
 
 ```bash
-npm i -D @trunkio/launcher
+npm i -g @trunkio/launcher
 ```
 
 ## Writing
@@ -61,6 +65,9 @@ We have adopted [Google’s Developer Documentation Style Guide](https://develop
 ```bash
 vale --glob='*.{mdx}' *
 ```
+
+A [Vale VS Code extension](https://marketplace.visualstudio.com/items?itemName=ChrisChinchilla.vale-vscode) is also available,
+and is included in the recommended extensions for this repo.
 
 ### Iconography
 

--- a/define-hosts.mdx
+++ b/define-hosts.mdx
@@ -30,7 +30,7 @@ Don't include secrets directly in the manifest!
 
 If your host requires authentication, you can specify `headers` and/or `queryParameters` properties.
 Those values can include _placeholders_ which resolve to their respective secrets at runtime.
-The secrets themselves are set via the Hypermode Console, where they're securely stored until needed.
+Set the actual secrets via the Hypermode Console, where they're securely stored until needed.
 </Warning>
 
 ## Properties
@@ -54,21 +54,21 @@ The secrets themselves are set via the Hypermode Console, where they're securely
 </ResponseField>
 
 <ResponseField name="headers" type="object">
-  If provided, these headers are used in all requests to the host. Each key-value pair is a header name and value.
+  If provided, requests to the host include these headers. Each key-value pair is a header name and value.
 
   Values may include variables using the `{{VARIABLE}}` template syntax, which resolve at runtime to secrets
   provided for each host, via the Hypermode Console.
 
   <Accordion title="Examples">
 
-  This example specifies a header named `Authorization` that uses the `Bearer` scheme, where the token is provided by a secret named `AUTH_TOKEN`:
+  This example specifies a header named `Authorization` that uses the `Bearer` scheme. A secret named `AUTH_TOKEN` provides the token:
   ```json
   "headers": {
     "Authorization": "Bearer {{AUTH_TOKEN}}"
   }
   ```
 
-  This example specifies a header named `X-API-Key` that is provided by a secret named `API_KEY`:
+  This example specifies a header named `X-API-Key` provided by a secret named `API_KEY`:
   ```json
   "headers": {
     "X-API-Key": "{{API_KEY}}"
@@ -76,7 +76,7 @@ The secrets themselves are set via the Hypermode Console, where they're securely
   ```
 
   You can use a special syntax for hosts that require [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
-  In this example, secrets named `USERNAME` and `PASSWORD` are combined and then base64-encoded to form a compliant `Authorization` header value:
+  In this example, secrets named `USERNAME` and `PASSWORD` combined and then are base64-encoded to form a compliant `Authorization` header value:
   ```json
   "headers": {
     "Authorization": "Basic {{base64(USERNAME:PASSWORD)}}"
@@ -87,14 +87,13 @@ The secrets themselves are set via the Hypermode Console, where they're securely
 </ResponseField>
 
 <ResponseField name="queryParameters" type="object">
-  If provided, these parameters appended to the URL for all requests to the host.  Each key-value pair is a parameter name and value.
+  If provided, requests to the host include these query parameters, appended to the URL. Each key-value pair is a parameter name and value.
 
-  Values may include variables using the `{{VARIABLE}}` template syntax, which are resolved at runtime to secrets
-  provided for each host, via the Hypermode Console.
+  Values may include variables using the `{{VARIABLE}}` template syntax, which resolve at runtime to secrets provided for each host, via the Hypermode Console.
 
   <Accordion title="Example">
 
-  This example specifies a query parameter named `key` that is provided by a secret named `API_KEY`:
+  This example specifies a query parameter named `key` provided by a secret named `API_KEY`:
   ```json
   "queryParameters": {
     "key": "{{API_KEY}}"

--- a/define-hosts.mdx
+++ b/define-hosts.mdx
@@ -22,15 +22,15 @@ The `hosts` object in the [project manifest](/manifest) allows you to define hos
 Each host requires a unique name, specified as a key, containing only alphanumeric characters and hyphens.
 
 <Note>
-You must include _either_ a `baseUrl` or an `endpoint` (not both).
+You must include either a `baseUrl` or an `endpoint` (not both).
 </Note>
 
 <Warning>
-Do not include secrets directly in the manifest!
+Don't include secrets directly in the manifest!
 
 If your host requires authentication, you can specify `headers` and/or `queryParameters` properties.
-These values can include _placeholders_ for secrets, which are resolved at runtime.
-The secrets themselves should be set via the Hypermode Console, where they are securely stored until needed.
+Those values can include _placeholders_ which resolve to their respective secrets at runtime.
+The secrets themselves are set via the Hypermode Console, where they're securely stored until needed.
 </Warning>
 
 ## Properties
@@ -54,28 +54,28 @@ The secrets themselves should be set via the Hypermode Console, where they are s
 </ResponseField>
 
 <ResponseField name="headers" type="object">
-  If provided, these headers are included in all requests to the host.  Each key-value pair is a header name and value.
+  If provided, these headers are used in all requests to the host. Each key-value pair is a header name and value.
 
-  Values may include variables using the `{{VARIABLE}}` template syntax, which are resolved at runtime to secrets
+  Values may include variables using the `{{VARIABLE}}` template syntax, which resolve at runtime to secrets
   provided for each host, via the Hypermode Console.
 
   <Accordion title="Examples">
 
-  This example specifies a header named `Authorization` that uses the `Bearer` scheme, where the token will be provided by a secret named `AUTH_TOKEN`:
+  This example specifies a header named `Authorization` that uses the `Bearer` scheme, where the token is provided by a secret named `AUTH_TOKEN`:
   ```json
   "headers": {
     "Authorization": "Bearer {{AUTH_TOKEN}}"
   }
   ```
 
-  This example specifies a header named `X-API-Key` that will be provided by a secret named `API_KEY`:
+  This example specifies a header named `X-API-Key` that is provided by a secret named `API_KEY`:
   ```json
   "headers": {
     "X-API-Key": "{{API_KEY}}"
   }
   ```
 
-  A special syntax can be used for hosts that use [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
+  You can use a special syntax for hosts that require [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
   In this example, secrets named `USERNAME` and `PASSWORD` are combined and then base64-encoded to form a compliant `Authorization` header value:
   ```json
   "headers": {
@@ -94,7 +94,7 @@ The secrets themselves should be set via the Hypermode Console, where they are s
 
   <Accordion title="Example">
 
-  This example specifies a query parameter named `key` that will be provided by a secret named `API_KEY`:
+  This example specifies a query parameter named `key` that is provided by a secret named `API_KEY`:
   ```json
   "queryParameters": {
     "key": "{{API_KEY}}"

--- a/define-hosts.mdx
+++ b/define-hosts.mdx
@@ -3,27 +3,103 @@ title: Define Hosts
 description: "Securely connect to your data"
 ---
 
-Hosts establish connectivity for AI models and other external endpoints. The [project manifest](/manifest) allows you to define hosts for secure access from within a function.
+Hosts establish connectivity for AI models and other external endpoints.
+The `hosts` object in the [project manifest](/manifest) allows you to define hosts, for secure access from within a function.
 
 ```json hypermode.json
 {
-  "hosts": [
-    {
-      "name": "openai",
-      "endpoint": "https://api.openai.com/v1",
-      "authHeader": "Authorization"
+  "hosts": {
+    "openai": {
+      "baseUrl": "https://api.openai.com/",
+      "headers": {
+        "Authorization": "Bearer {{API_KEY}}"
+      }
     }
-  ]
+  }
 }
 ```
 
+Each host requires a unique name, specified as a key, containing only alphanumeric characters and hyphens.
+
+<Note>
+You must include _either_ a `baseUrl` or an `endpoint` (not both).
+</Note>
+
+<Warning>
+Do not include secrets directly in the manifest!
+
+If your host requires authentication, you can specify `headers` and/or `queryParameters` properties.
+These values can include _placeholders_ for secrets, which are resolved at runtime.
+The secrets themselves should be set via the Hypermode Console, where they are securely stored until needed.
+</Warning>
+
 ## Properties
 
-<ResponseField name="name" type="string" required>
-  Internal name of your host. Used for indicating the host of a model or for a
-  connection.
+<ResponseField name="baseUrl" type="string" required>
+  Base URL for connections to the host.
+  - Must end with a trailing slash.
+  - May contain path segments if necessary.
+
+  Example: `"https://api.example.com/v1/"`
+
+  _If providing the entire URL, use the `endpoint` field instead._
 </ResponseField>
 
 <ResponseField name="endpoint" type="string" required>
-  URL and base path for connections to the host.
+  Full URL endpoint for connections to the host.
+
+  Example: `"https://models.example.com/v1/classifier"`
+  
+  _If providing only the base of the URL, use the `baseUrl` field instead._
+</ResponseField>
+
+<ResponseField name="headers" type="object">
+  If provided, these headers are included in all requests to the host.  Each key-value pair is a header name and value.
+
+  Values may include variables using the `{{VARIABLE}}` template syntax, which are resolved at runtime to secrets
+  provided for each host, via the Hypermode Console.
+
+  <Accordion title="Examples">
+
+  This example specifies a header named `Authorization` that uses the `Bearer` scheme, where the token will be provided by a secret named `AUTH_TOKEN`:
+  ```json
+  "headers": {
+    "Authorization": "Bearer {{AUTH_TOKEN}}"
+  }
+  ```
+
+  This example specifies a header named `X-API-Key` that will be provided by a secret named `API_KEY`:
+  ```json
+  "headers": {
+    "X-API-Key": "{{API_KEY}}"
+  }
+  ```
+
+  A special syntax can be used for hosts that use [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
+  In this example, secrets named `USERNAME` and `PASSWORD` are combined and then base64-encoded to form a compliant `Authorization` header value:
+  ```json
+  "headers": {
+    "Authorization": "Basic {{base64(USERNAME:PASSWORD)}}"
+  }
+  ```
+
+  </Accordion>
+</ResponseField>
+
+<ResponseField name="queryParameters" type="object">
+  If provided, these parameters appended to the URL for all requests to the host.  Each key-value pair is a parameter name and value.
+
+  Values may include variables using the `{{VARIABLE}}` template syntax, which are resolved at runtime to secrets
+  provided for each host, via the Hypermode Console.
+
+  <Accordion title="Example">
+
+  This example specifies a query parameter named `key` that will be provided by a secret named `API_KEY`:
+  ```json
+  "queryParameters": {
+    "key": "{{API_KEY}}"
+  }
+  ```
+
+  </Accordion>
 </ResponseField>

--- a/define-hosts.mdx
+++ b/define-hosts.mdx
@@ -21,9 +21,7 @@ The `hosts` object in the [project manifest](/manifest) allows you to define hos
 
 Each host requires a unique name, specified as a key, containing only alphanumeric characters and hyphens.
 
-<Note>
-You must include either a `baseUrl` or an `endpoint` (not both).
-</Note>
+<Note>You must include either a `baseUrl` or an `endpoint` (not both).</Note>
 
 <Warning>
 Don't include secrets directly in the manifest!
@@ -31,6 +29,7 @@ Don't include secrets directly in the manifest!
 If your host requires authentication, you can specify `headers` and/or `queryParameters` properties.
 Those values can include _placeholders_ which resolve to their respective secrets at runtime.
 Set the actual secrets via the Hypermode Console, where they're securely stored until needed.
+
 </Warning>
 
 ## Properties
@@ -40,48 +39,53 @@ Set the actual secrets via the Hypermode Console, where they're securely stored 
   - Must end with a trailing slash.
   - May contain path segments if necessary.
 
-  Example: `"https://api.example.com/v1/"`
+Example: `"https://api.example.com/v1/"`
 
-  _If providing the entire URL, use the `endpoint` field instead._
+_If providing the entire URL, use the `endpoint` field instead._
+
 </ResponseField>
 
 <ResponseField name="endpoint" type="string" required>
   Full URL endpoint for connections to the host.
 
-  Example: `"https://models.example.com/v1/classifier"`
-  
-  _If providing only the base of the URL, use the `baseUrl` field instead._
+Example: `"https://models.example.com/v1/classifier"`
+
+_If providing only the base of the URL, use the `baseUrl` field instead._
+
 </ResponseField>
 
 <ResponseField name="headers" type="object">
   If provided, requests to the host include these headers. Each key-value pair is a header name and value.
 
-  Values may include variables using the `{{VARIABLE}}` template syntax, which resolve at runtime to secrets
-  provided for each host, via the Hypermode Console.
+Values may include variables using the `{{VARIABLE}}` template syntax, which resolve at runtime to secrets
+provided for each host, via the Hypermode Console.
 
   <Accordion title="Examples">
 
-  This example specifies a header named `Authorization` that uses the `Bearer` scheme. A secret named `AUTH_TOKEN` provides the token:
-  ```json
-  "headers": {
-    "Authorization": "Bearer {{AUTH_TOKEN}}"
-  }
-  ```
+This example specifies a header named `Authorization` that uses the `Bearer` scheme. A secret named `AUTH_TOKEN` provides the token:
 
-  This example specifies a header named `X-API-Key` provided by a secret named `API_KEY`:
-  ```json
-  "headers": {
-    "X-API-Key": "{{API_KEY}}"
-  }
-  ```
+```json
+"headers": {
+  "Authorization": "Bearer {{AUTH_TOKEN}}"
+}
+```
 
-  You can use a special syntax for hosts that require [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
-  In this example, secrets named `USERNAME` and `PASSWORD` combined and then are base64-encoded to form a compliant `Authorization` header value:
-  ```json
-  "headers": {
-    "Authorization": "Basic {{base64(USERNAME:PASSWORD)}}"
-  }
-  ```
+This example specifies a header named `X-API-Key` provided by a secret named `API_KEY`:
+
+```json
+"headers": {
+  "X-API-Key": "{{API_KEY}}"
+}
+```
+
+You can use a special syntax for hosts that require [HTTP basic authentication](https://en.wikipedia.org/wiki/Basic_access_authentication).
+In this example, secrets named `USERNAME` and `PASSWORD` combined and then are base64-encoded to form a compliant `Authorization` header value:
+
+```json
+"headers": {
+  "Authorization": "Basic {{base64(USERNAME:PASSWORD)}}"
+}
+```
 
   </Accordion>
 </ResponseField>
@@ -89,16 +93,17 @@ Set the actual secrets via the Hypermode Console, where they're securely stored 
 <ResponseField name="queryParameters" type="object">
   If provided, requests to the host include these query parameters, appended to the URL. Each key-value pair is a parameter name and value.
 
-  Values may include variables using the `{{VARIABLE}}` template syntax, which resolve at runtime to secrets provided for each host, via the Hypermode Console.
+Values may include variables using the `{{VARIABLE}}` template syntax, which resolve at runtime to secrets provided for each host, via the Hypermode Console.
 
   <Accordion title="Example">
 
-  This example specifies a query parameter named `key` provided by a secret named `API_KEY`:
-  ```json
-  "queryParameters": {
-    "key": "{{API_KEY}}"
-  }
-  ```
+This example specifies a query parameter named `key` provided by a secret named `API_KEY`:
+
+```json
+"queryParameters": {
+  "key": "{{API_KEY}}"
+}
+```
 
   </Accordion>
 </ResponseField>

--- a/define-models.mdx
+++ b/define-models.mdx
@@ -42,7 +42,8 @@ Each model requires a unique name, specified as a key, containing only alphanume
 
 - Specify `"hypermode"` for models that are automatically deployed by Hypermode.
 - Otherwise, specify a name that matches a host defined in the [`hosts`](/define-hosts) section of the manifest.
-  </ResponseField>
+
+</ResponseField>
 
 ## Auto-deployed models
 

--- a/define-models.mdx
+++ b/define-models.mdx
@@ -3,56 +3,47 @@ title: Define Models
 description: "Try a new model with a few lines of code"
 ---
 
-AI models are a core resource for inferencing. The [project manifest](/manifest) allows you to easily define models whether hosted by Hypermode or another host.
+AI models are a core resource for inferencing.
+The `models` object in the [project manifest](/manifest) allows you to easily define models, whether hosted by Hypermode or another host.
 
 ```json hypermode.json
 {
-  "models": [
-    {
-      "name": "sentiment-classifier",
+  "models": {
+    "sentiment-classifier": {
       "task": "classification",
       "sourceModel": "distilbert/distilbert-base-uncased-finetuned-sst-2-english",
       "provider": "hugging-face",
       "host": "hypermode"
     }
-  ]
+  }
 }
 ```
 
+Each model requires a unique name, specified as a key, containing only alphanumeric characters and hyphens.
+
 ## Properties
 
-<ResponseField name="name" type="string" required>
-  Internal name of your AI model. Used for indicating the model to use in an API
-  call.
-</ResponseField>
-
 <ResponseField name="task" type="string" required>
-  Training intent of model, such as `classification` or `embedding`.
+  Training intent of the model.  Currently, must be one of: `classification`, `embedding`, or `generation`.
 </ResponseField>
 
 <ResponseField name="sourceModel" type="string" required>
-  Relative path of model within provider.
+  Original relative path of the model within the provider's repository.
 </ResponseField>
 
 <ResponseField name="provider" type="string" required>
-  Source location of model, such as `hugging-face` or `openai`.
+  Organization or directory that provided the source model, such as `hugging-face` or `openai`.
 </ResponseField>
 
 <ResponseField name="host" type="string" required>
-  Runtime provider of model.
-  <Expandable title="host types">
-    <ResponseField name="hypermode" type="string">
-      Dynamically deployed models on Hypermode.
-    </ResponseField>
-    <ResponseField name="custom" type="string">
-      Fine-tuned models on Hypermode.
-    </ResponseField>
-    <ResponseField name="..." type="string">
-      Name of a project-defined [host](/define-hosts).
-    </ResponseField>
-  </Expandable>
+  Location where the model instance is being hosted.
+
+  - Specify `"hypermode"` for models that are automatically deployed by Hypermode.
+  - Otherwise, specify a name that matches a host defined in the [`hosts`](/define-hosts) section of the manifest.
 </ResponseField>
 
 ## Auto-deployed models
 
-When using `hugging-face` as the `provider` and `hypermode` as the `host`, Hypermode automatically deploys a dedicated instance of the defined `sourceModel` when deploying your project. Your project's functions securely connect to the hosted model, with no further configuration required.
+When using `hugging-face` as the `provider` and `hypermode` as the `host`, Hypermode automatically deploys a dedicated
+instance of the defined `sourceModel` when deploying your project. Your project's functions securely connect to the
+hosted model, with no further configuration required.

--- a/define-models.mdx
+++ b/define-models.mdx
@@ -24,7 +24,8 @@ Each model requires a unique name, specified as a key, containing only alphanume
 ## Properties
 
 <ResponseField name="task" type="string" required>
-  Training intent of the model. Currently, must be one of: `classification`, `embedding`, or `generation`.
+  Training intent of the model. Currently, must be one of: `classification`,
+  `embedding`, or `generation`.
 </ResponseField>
 
 <ResponseField name="sourceModel" type="string" required>
@@ -32,15 +33,16 @@ Each model requires a unique name, specified as a key, containing only alphanume
 </ResponseField>
 
 <ResponseField name="provider" type="string" required>
-  Organization or directory that provided the source model, such as `hugging-face` or `openai`.
+  Organization or directory that provided the source model, such as
+  `hugging-face` or `openai`.
 </ResponseField>
 
 <ResponseField name="host" type="string" required>
   Host for the model instance.
 
-  - Specify `"hypermode"` for models that are automatically deployed by Hypermode.
-  - Otherwise, specify a name that matches a host defined in the [`hosts`](/define-hosts) section of the manifest.
-</ResponseField>
+- Specify `"hypermode"` for models that are automatically deployed by Hypermode.
+- Otherwise, specify a name that matches a host defined in the [`hosts`](/define-hosts) section of the manifest.
+  </ResponseField>
 
 ## Auto-deployed models
 

--- a/define-models.mdx
+++ b/define-models.mdx
@@ -24,7 +24,7 @@ Each model requires a unique name, specified as a key, containing only alphanume
 ## Properties
 
 <ResponseField name="task" type="string" required>
-  Training intent of the model.  Currently, must be one of: `classification`, `embedding`, or `generation`.
+  Training intent of the model. Currently, must be one of: `classification`, `embedding`, or `generation`.
 </ResponseField>
 
 <ResponseField name="sourceModel" type="string" required>
@@ -36,7 +36,7 @@ Each model requires a unique name, specified as a key, containing only alphanume
 </ResponseField>
 
 <ResponseField name="host" type="string" required>
-  Location where the model instance is being hosted.
+  Location where the model instance is hosted.
 
   - Specify `"hypermode"` for models that are automatically deployed by Hypermode.
   - Otherwise, specify a name that matches a host defined in the [`hosts`](/define-hosts) section of the manifest.

--- a/define-models.mdx
+++ b/define-models.mdx
@@ -36,7 +36,7 @@ Each model requires a unique name, specified as a key, containing only alphanume
 </ResponseField>
 
 <ResponseField name="host" type="string" required>
-  Location where the model instance is hosted.
+  Host for the model instance.
 
   - Specify `"hypermode"` for models that are automatically deployed by Hypermode.
   - Otherwise, specify a name that matches a host defined in the [`hosts`](/define-hosts) section of the manifest.


### PR DESCRIPTION
Updates the `models` and `hosts` pages, to be merged after Runtime v0.8.0 prod deployment.

Also adds some VS Code settings and improves instructions in the readme.

Completes HYP-1273