### PR TITLE
add explicit connection types

### DIFF
--- a/modus/app-manifest.mdx
+++ b/modus/app-manifest.mdx
@@ -136,6 +136,7 @@ invoke externally hosted AI [models](/modus/sdk/models).
 {
   "connections": {
     "openai": {
+      "type": "http",
       "baseUrl": "https://api.openai.com/",
       "headers": {
         "Authorization": "Bearer {{API_KEY}}"

--- a/modus/model-invoking.mdx
+++ b/modus/model-invoking.mdx
@@ -51,6 +51,7 @@ examples:
   // for externally hosted models, explicitly define the connection
   "connections": {
     "openai": {
+      "type": "http",
       "baseUrl": "https://api.openai.com/",
       "headers": {
         "Authorization": "Bearer {{API_KEY}}"
@@ -75,6 +76,7 @@ examples:
   // for externally hosted models, explicitly define the connection
   "connections": {
     "anthropic": {
+      "type": "http",
       "baseUrl": "https://api.anthropic.com/",
       "headers": {
         "x-api-key": "{{API_KEY}}",

--- a/modus/search.mdx
+++ b/modus/search.mdx
@@ -188,6 +188,7 @@ export function embed(texts: string[]): f32[][] {
   },
   "connections": {
     "openai": {
+      "type": "http",
       "baseUrl": "https://api.openai.com/",
       "headers": {
         "Authorization": "Bearer {{API_KEY}}"


### PR DESCRIPTION
The `type` parameter on connections (formerly hosts) is now required. Adding to all references.