### PR TITLE
remove cURL install instructions for CLIs

### DIFF
--- a/hyp-cli.mdx
+++ b/hyp-cli.mdx
@@ -9,26 +9,11 @@ When using Hyp CLI alongside the Modus CLI, users get access to
 
 ## Install
 
-Install Hyp CLI via a cURL command or npm.
+Install Hyp CLI via npm.
 
-    <Tabs>
-      <Tab title="MacOS + Linux">
-        ```bash
-        curl install.hypermode.com/hyp.sh -sSfL | bash
-        ```
-
-        or
-
-        ```bash
-        npm install -g @hypermode/hyp-cli
-        ```
-      </Tab>
-      <Tab title="Windows">
-        ```bash
-        npm install -g @hypermode/hyp-cli
-        ```
-      </Tab>
-    </Tabs>
+```bash
+npm install -g @hypermode/hyp-cli
+```
 
 ## Commands
 

--- a/modus/modus-cli.mdx
+++ b/modus/modus-cli.mdx
@@ -8,27 +8,11 @@ running it locally.
 
 ## Install
 
-Install Modus CLI via a cURL command or npm.
+Install Modus CLI via npm.
 
-<Tabs>
-  <Tab title="MacOS + Linux">
-    ```bash
-    curl install.hypermode.com/modus.sh -sSfL | bash
-    ```
-
-    or
-
-    ```bash
-    npm install -g @hypermode/modus-cli
-    ```
-
-  </Tab>
-  <Tab title="Windows">
-    ```bash
-    npm install -g @hypermode/modus-cli
-    ```
-  </Tab>
-</Tabs>
+```bash
+npm install -g @hypermode/modus-cli
+```
 
 ## Commands
 

--- a/modus/quickstart.mdx
+++ b/modus/quickstart.mdx
@@ -19,26 +19,11 @@ learn how to use the basic components of a Modus app and how to run it locally.
 <Steps>
   <Step title="Install the Modus CLI">
     The Modus CLI provides a set of commands to help you create, build, and run your Modus apps.
-    You can install the CLI using cURL or npm.
+    Install the CLI using npm.
 
-    <Tabs>
-      <Tab title="MacOS + Linux">
-        ```bash
-        curl install.hypermode.com/modus.sh -sSfL | bash
-        ```
-
-        or
-
-        ```bash
-        npm install -g @hypermode/modus-cli
-        ```
-      </Tab>
-      <Tab title="Windows">
-        ```bash
-        npm install -g @hypermode/modus-cli
-        ```
-      </Tab>
-    </Tabs>
+    ```bash
+    npm install -g @hypermode/modus-cli
+    ```
 
   </Step>
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -36,13 +36,7 @@ the basic components of a Modus app and how to deploy it to Hypermode.
         Once you've selected your repository, click "Import" to deploy your app.
       </Tab>
       <Tab title="Hyp CLI">
-        Install the Hyp CLI via cURL (macOS + Linux) or npm (all platforms):
-
-        ```bash
-        curl install.hypermode.com/hyp.sh -sSfL | bash
-        ```
-
-        or
+        Install the Hyp CLI via npm.
 
         ```bash
         npm install -g @hypermode/hyp-cli

--- a/work-locally.mdx
+++ b/work-locally.mdx
@@ -12,17 +12,9 @@ experimentation with new AI models.
 
 For access to hosted models, install the Hyp CLI to augment Modus.
 
-<CodeGroup>
-
-```bash MacOS + Linux
-curl -sSL http://install.hypermode.com/hyp.sh | bash
-```
-
-```js Windows
+```bash
 npm install -g @hypermode/hyp-cli
 ```
-
-</CodeGroup>
 
 ## Log into Hyp
 


### PR DESCRIPTION
hiding cURL instructions until we have auto-prompting updates through that channel