### PR TITLE
Fix import for collection

### DIFF
--- a/modus/sdk/collections.mdx
+++ b/modus/sdk/collections.mdx
@@ -16,7 +16,7 @@ import github.com/hypermodeinc/modus/sdk/go/pkg/collections
 ```
 
 ```ts AssemblyScript
-import { collections } from "@hypermode/functions-as"
+import { collections } from "@hypermode/modus-sdk-as"
 ```
 
 </CodeGroup>

--- a/modus/sdk/collections.mdx
+++ b/modus/sdk/collections.mdx
@@ -16,7 +16,7 @@ import github.com/hypermodeinc/modus/sdk/go/pkg/collections
 ```
 
 ```ts AssemblyScript
-import { collections } from "@hypermode/modus-sdk-as"
+import { collections } from "@hypermode/functions-as"
 ```
 
 </CodeGroup>


### PR DESCRIPTION
Incorrect import path for the collections module. It was previously importing from @hypermode/function-as, which I believe is incorrect. The path has been updated to the correct module, @hypermode/modus-sdk-as.