### PR TITLE
Deploy docs - add GH linking info

### DIFF
--- a/deploy.mdx
+++ b/deploy.mdx
@@ -13,10 +13,10 @@ in the [app manifest](/modus/app-manifest).
 
 ## Link your project to GitHub
 
-After you push your Modus app to GitHub, you can link your Hypermode project
-to the repo through the Hyp CLI.
+After you push your Modus app to GitHub, you can link your Hypermode project to
+the repo through the Hyp CLI.
 
-```
+```bash
 hyp link
 ```
 

--- a/deploy.mdx
+++ b/deploy.mdx
@@ -22,8 +22,8 @@ hyp link
 
 ## Build
 
-When you link your project with Hypermode, the Hyp CLI adds a GitHub
-Actions workflow to your repo that builds your Modus app to Hypermode on commit.
+When you link your project with Hypermode, the Hyp CLI adds a GitHub Actions
+workflow to your repo that builds your Modus app to Hypermode on commit.
 
 ## Deploy
 

--- a/deploy.mdx
+++ b/deploy.mdx
@@ -11,6 +11,37 @@ in the [app manifest](/modus/app-manifest).
   Preview environments for live validation of pull requests are in development.
 </Note>
 
+## Link your app to GitHub
+
+After you [create a Modus app](/modus/quickstart#building-your-first-modus-app),
+you can link the app to GitHub using the Hypermode Console or through the
+terminal with the Hyp CLI.
+
+<Tabs>
+  <Tab title="Hypermode Console">
+    Navigate to the [**Hypermode Console**](https://hypermode.com/go) and click **New Project**.
+    Connect your GitHub account when prompted and select the repository you want to import.
+    Click "Import" to deploy your app.
+
+    After project creation, Hypermode initiates a runtime for your app and establishes connections to any [**Hypermode-hosted models**](https://docs.hypermode.com/hosted-models).
+
+  </Tab>
+  <Tab title="Hyp CLI">
+    Install the Hyp CLI via npm.
+
+    ```bash
+    npm install -g @hypermode/hyp-cli
+    ```
+
+    Run the following command in your terminal to import and deploy your Modus app to Hypermode. This creates your Hypermode project automatically.
+
+    ```bash
+    hyp link
+    ```
+
+  </Tab>
+</Tabs>
+
 ## Build
 
 When you initialize your project with Hypermode, the Hyp CLI adds a GitHub

--- a/deploy.mdx
+++ b/deploy.mdx
@@ -13,7 +13,8 @@ in the [app manifest](/modus/app-manifest).
 
 ## Link your app to GitHub
 
-After you [create a Modus app](/modus/quickstart#building-your-first-modus-app),
+After you
+[create and initialize your Modus app](/modus/quickstart#building-your-first-modus-app),
 you can link the app to GitHub using the Hypermode Console or through the
 terminal with the Hyp CLI.
 
@@ -53,5 +54,5 @@ On successful build of your project, Hypermode automatically deploys your
 project changes. For [hosted models](/hosted-models), Hypermode creates a
 connection for your app to a shared or dedicated model instance.
 
-You can view the deployment status from the Deployment tab within the Hypermode
+You can view the deployment status from the Deployments tab within the Hypermode
 Console.

--- a/deploy.mdx
+++ b/deploy.mdx
@@ -11,16 +11,18 @@ in the [app manifest](/modus/app-manifest).
   Preview environments for live validation of pull requests are in development.
 </Note>
 
-## Link your app to GitHub
+## Link your project to GitHub
 
-After you
-[build your Modus app](/modus/quickstart#building-your-first-modus-app), you can
-[create a new project](/create-project) and link it to GitHub using the
-Hypermode Console or through the terminal with the Hyp CLI.
+After you push your Modus app to GitHub, you can link your Hypermode project
+to the repo through the Hyp CLI.
+
+```
+hyp link
+```
 
 ## Build
 
-When you initialize your project with Hypermode, the Hyp CLI adds a GitHub
+When you link your project with Hypermode, the Hyp CLI adds a GitHub
 Actions workflow to your repo that builds your Modus app to Hypermode on commit.
 
 ## Deploy

--- a/deploy.mdx
+++ b/deploy.mdx
@@ -14,34 +14,9 @@ in the [app manifest](/modus/app-manifest).
 ## Link your app to GitHub
 
 After you
-[create and initialize your Modus app](/modus/quickstart#building-your-first-modus-app),
-you can link the app to GitHub using the Hypermode Console or through the
-terminal with the Hyp CLI.
-
-<Tabs>
-  <Tab title="Hypermode Console">
-    Navigate to the [**Hypermode Console**](https://hypermode.com/go) and click **New Project**.
-    Connect your GitHub account when prompted and select the repository you want to import.
-    Click "Import" to deploy your app.
-
-    After project creation, Hypermode initiates a runtime for your app and establishes connections to any [**Hypermode-hosted models**](https://docs.hypermode.com/hosted-models).
-
-  </Tab>
-  <Tab title="Hyp CLI">
-    Install the Hyp CLI via npm.
-
-    ```bash
-    npm install -g @hypermode/hyp-cli
-    ```
-
-    Run the following command in your terminal to import and deploy your Modus app to Hypermode. This creates your Hypermode project automatically.
-
-    ```bash
-    hyp link
-    ```
-
-  </Tab>
-</Tabs>
+[build your Modus app](/modus/quickstart#building-your-first-modus-app), you can
+[create a new project](/create-project) and link it to GitHub using the
+Hypermode Console or through the terminal with the Hyp CLI.
 
 ## Build
 


### PR DESCRIPTION
Added info explaining how to link your Modus app to GH using the console & the CLI. Note that this info is very similar to what we already have in the Quickstart, but I think that's okay.

Tried to make this somewhat concise, but are there things we should add? (Or remove?) 🤔 

(For reference, [message in Slack](https://hypermode.slack.com/archives/C075TV4S93L/p1732905826616929))