### PR TITLE
Update Docker command from `docker-compose up` to `docker compose up`

### DIFF
--- a/modus/search.mdx
+++ b/modus/search.mdx
@@ -429,7 +429,7 @@ Start the Collections PostgreSQL database using the local Docker Compose script:
 
 ```sh
 cd modus/runtime/tools/local
-docker-compose up
+docker compose up
 ```
 
   </Step>


### PR DESCRIPTION
I noticed that the command `docker-compose up` did not work as intended when deploying my modus API locally after I updated to Docker v4.37.2. 

I changed `docker-compose up` to `docker-compose up` and tested it locally using Docker v4.37.2. The updated command worked as expected, starting the PostgreSQL instance without issues.


This change is specific to newer Docker versions where the `docker-compose` may be  deprecated.


Optionally, we could add the newer command as a second option for those using a new version of docker