### PR TITLE
fix inline code styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,0 +1,9 @@
+/* default code padding is 2px 8px, which is too wide */
+code {
+  padding: 2px 4px !important;
+}
+
+/* anchors around code blocks don't need additional decoration */
+a code {
+  text-decoration: none !important;
+}


### PR DESCRIPTION
There's too much left-right padding around inline code blocks.

Before:

![image](https://github.com/user-attachments/assets/977a13be-38b0-467c-999d-805187f2b15b)

After:

![image](https://github.com/user-attachments/assets/2b4fd123-41dd-4b01-9ba2-0516bc424154)

Additionally, inline code blocks with links had extra bits of underlining that look strange on the edges, rendered with two different thicknesses:

Before:

![image](https://github.com/user-attachments/assets/e5cbbeb1-9461-47b5-a654-9bbb4183ec9f)

After:

![image](https://github.com/user-attachments/assets/f2beff77-375c-4272-a71a-b6c45e71d556)
