### PR TITLE
update outdated Go SDK import paths

### DIFF
--- a/modus/api-generation.mdx
+++ b/modus/api-generation.mdx
@@ -34,8 +34,8 @@ package main
 import (
   "errors"
   "fmt"
-  "github.com/hypermodeAI/functions-go/pkg/models"
-  "github.com/hypermodeAI/functions-go/pkg/models/experimental"
+  "github.com/hypermodeinc/modus/sdk/go/models"
+  "github.com/hypermodeinc/modus/sdk/go/models/experimental"
 )
 
 const modelName = "my-classifier"

--- a/modus/search.mdx
+++ b/modus/search.mdx
@@ -136,8 +136,8 @@ Create the embedding function using the embedding model:
 package main
 
 import (
-"github.com/hypermodeAI/functions-go/pkg/models"
-"github.com/hypermodeAI/functions-go/pkg/models/experimental"
+  "github.com/hypermodeinc/modus/sdk/go/models"
+  "github.com/hypermodeinc/modus/sdk/go/models/experimental"
 )
 
 func Embed(text []string) ([][]float32, error) {
@@ -204,8 +204,8 @@ Create the embedding function using the embedding model:
 
 ```go Go
 import (
-  "github.com/hypermodeAI/functions-go/pkg/models"
-  "github.com/hypermodeAI/functions-go/pkg/models/experimental"
+  "github.com/hypermodeinc/modus/sdk/go/models"
+  "github.com/hypermodeinc/modus/sdk/go/models/experimental"
 )
 
 func Embed(texts ...string) ([][]float32, error) {


### PR DESCRIPTION
there are several places where we are still using the old import path (`github.com/hypermodeAI/functions-go/pkg`). this PR updates those references.