### PR TITLE
port open Dgraph Docs PRs

### DIFF
--- a/dgraph/dql/schema.mdx
+++ b/dgraph/dql/schema.mdx
@@ -79,7 +79,7 @@ notation):
   set {
     <_:jedi1> <character_name> "Luke Skywalker" .
     <_:leia> <character_name> "Leia" .
-    <_:sith1> <character_name> "Anakin" (aka="Darth Vador",villain=true).
+    <_:sith1> <character_name> "Anakin" (aka="Darth Vader",villain=true).
     <_:sith1> <has_for_child> <_:jedi1> .
     <_:sith1> <has_for_child> <_:leia> .
   }

--- a/dgraph/graphql/http.mdx
+++ b/dgraph/graphql/http.mdx
@@ -565,6 +565,9 @@ trace information for the request.
 - `"tracing"`: Displays performance tracing data in [Apollo
   Tracing][apollo-tracing] format. This includes the duration of the whole query
   and the duration of each operation.
+- `"dql_query"`: Optional, displays the translated DQL query Dgraph composed.
+  This is only output when the GraphQL debug superflag
+  `(--graphql "debug=true;")` is set.
 
 [apollo-tracing]: https://github.com/apollographql/apollo-tracing
 


### PR DESCRIPTION
Bringing over open PRs from old Dgraph Docs:
- https://github.com/dgraph-io/dgraph-docs/pull/690
- https://github.com/dgraph-io/dgraph-docs/pull/689

Thank you @DanGM96 and @matthewmcneely for the contributions!