### PR TITLE
docs: add header on model introspection

### DIFF
--- a/model-router.mdx
+++ b/model-router.mdx
@@ -677,6 +677,8 @@ models.
   [help@hypermode.com](mailto:help@hypermode.com).
 </Note>
 
+### Model Introspection
+
 The full list of available models is available via the API.
 
 ```bash curl


### PR DESCRIPTION
I found that the codeblock showing how to introspect was hidden among this document, adding this header makes it more approachable.