### PR TITLE
add mutation conventions

### DIFF
--- a/modus/api-generation.mdx
+++ b/modus/api-generation.mdx
@@ -139,21 +139,28 @@ function classify(text: string, threshold: f32): ClassifierResult[] {
   </Tab>
 </Tabs>
 
-## Generating Mutations
+## Generating mutations
 
-By default, all exported functions are generated as GraphQL **queries** unless they follow specific naming conventions that indicate they perform mutations (data modifications). 
+By default, all exported functions are generated as GraphQL **queries** unless
+they follow specific naming conventions that indicate they perform mutations
+(data modifications).
 
-Functions are automatically classified as **mutations** when they start with these prefixes:
+Functions are automatically classified as **mutations** when they start with
+these prefixes:
+
 - `mutate`
 - `post`, `patch`, `put`, `delete`
 - `add`, `update`, `insert`, `upsert`
 - `create`, `edit`, `save`, `remove`, `alter`, `modify`
 
 For example:
+
 - `getUserById` → Query
-- `listProducts` → Query  
+- `listProducts` → Query
 - `addUser` → Mutation
 - `updateProduct` → Mutation
 - `deleteOrder` → Mutation
 
-The prefix is detected precisely - `addPost` becomes a mutation, but `additionalPosts` remains a query since "additional" doesn't match the exact "add" prefix pattern.
+The prefix is detected precisely - `addPost` becomes a mutation, but
+`additionalPosts` remains a query since "additional" doesn't match the exact
+"add" prefix pattern.

--- a/modus/api-generation.mdx
+++ b/modus/api-generation.mdx
@@ -138,3 +138,22 @@ function classify(text: string, threshold: f32): ClassifierResult[] {
 
   </Tab>
 </Tabs>
+
+## Generating Mutations
+
+By default, all exported functions are generated as GraphQL **queries** unless they follow specific naming conventions that indicate they perform mutations (data modifications). 
+
+Functions are automatically classified as **mutations** when they start with these prefixes:
+- `mutate`
+- `post`, `patch`, `put`, `delete`
+- `add`, `update`, `insert`, `upsert`
+- `create`, `edit`, `save`, `remove`, `alter`, `modify`
+
+For example:
+- `getUserById` → Query
+- `listProducts` → Query  
+- `addUser` → Mutation
+- `updateProduct` → Mutation
+- `deleteOrder` → Mutation
+
+The prefix is detected precisely - `addPost` becomes a mutation, but `additionalPosts` remains a query since "additional" doesn't match the exact "add" prefix pattern.


### PR DESCRIPTION
Was going back and forth wondering why my function was not being exposed via the graphql mutations api, turns out its a hardcoded convention in the codebase located here: 

* https://github.com/hypermodeinc/modus/blob/main/runtime/graphql/schemagen/conventions.go