### PR TITLE
Fix typo in quickstart documentation

### DIFF
--- a/dgraph/quickstart.mdx
+++ b/dgraph/quickstart.mdx
@@ -269,7 +269,7 @@ results of our query:
 
 The previous query used the `type()` function to find the starting point of our
 graph traversal. We can use more complex functions to filter by string
-comparison operator, and others, however to use these function we must first
+comparison operator, and others, however to use these functions we must first
 update the graph schema to create an index on the predicates we want to use in
 these functions.
 


### PR DESCRIPTION
Found a small typo.